### PR TITLE
Add file limitation info

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,8 @@ for student in students:
 
 ## Upload a file to Edupage's cloud
 The file will be hosted forever (and for free) on Edupage's servers. The file is tied to your user account, but anybody with a link can view it.
+
+Anyway, Edupage limits file size to 50 MB and the file can have only some extensions. All supported file extensions could be found on this [Edupage help site](https://help.edupage.org/?p=u1/u113/u132/u362/u467).
 ```python
 from edupage_api import Edupage, EduStudent
 from edupage_api.cloud import EduCloud


### PR DESCRIPTION
After few tries I found, that files uploaded to Edupage cloud are limited by size and by extension

- [x] Add file limitation info to `README.md`

@ivanhrabcak, if you will merge, please use "Squash and Merge"...