### PR TITLE
Fix `get_teachers`

### DIFF
--- a/edupage_api/__init__.py
+++ b/edupage_api/__init__.py
@@ -469,7 +469,7 @@ class Edupage:
         if dbi == None:
             return None
 
-        id_util = IdUtil(dbi)
+        id_util = IdUtil(self.data)
 
         teachers = dbi.get("teachers")
 


### PR DESCRIPTION
Fix `AttributeError: 'NoneType' object has no attribute 'get'` error, when running `Get a list of teachers` example