### PR TITLE
Add new methods for getting text grades

### DIFF
--- a/edupage_api/__init__.py
+++ b/edupage_api/__init__.py
@@ -209,10 +209,10 @@ class Edupage(EdupageModule):
         """Get a list of all text grades (commendations).
 
         Returns:
-            list[EduGrade]: List of `EduTextGrade`s
+            list[EduTextGrade]: List of `EduTextGrade`s
         """
 
-        return Grades(self).get_grades(year=None, term=None)
+        return Grades(self).get_text_grades(year=None, term=None)
 
     def get_grades_for_term(self, year: int, term: Term) -> list[EduGrade]:
         """Get a list of all available grades for a given year and term

--- a/edupage_api/__init__.py
+++ b/edupage_api/__init__.py
@@ -10,7 +10,7 @@ from edupage_api.classes import Class, Classes
 from edupage_api.classrooms import Classroom, Classrooms
 from edupage_api.cloud import Cloud, EduCloudFile
 from edupage_api.custom_request import CustomRequest
-from edupage_api.grades import EduGrade, Grades, Term
+from edupage_api.grades import EduGrade, EduTextGrade, Grades, Term
 from edupage_api.login import Login, TwoFactorLogin
 from edupage_api.lunches import Lunches, Meals
 from edupage_api.messages import Messages
@@ -204,6 +204,15 @@ class Edupage(EdupageModule):
         """
 
         return Grades(self).get_grades(year=None, term=None)
+    
+    def get_text_grades(self) -> list[EduTextGrade]:
+        """Get a list of all text grades (commendations).
+
+        Returns:
+            list[EduGrade]: List of `EduTextGrade`s
+        """
+
+        return Grades(self).get_grades(year=None, term=None)
 
     def get_grades_for_term(self, year: int, term: Term) -> list[EduGrade]:
         """Get a list of all available grades for a given year and term
@@ -213,6 +222,15 @@ class Edupage(EdupageModule):
         """
 
         return Grades(self).get_grades(year=year, term=term)
+    
+    def get_text_grades_for_term(self, year: int, term: Term) -> list[EduTextGrade]:
+         """Get a list of all available text grades (commendations) for a given year and term
+
+        Returns:
+            list[EduTextGrade]: List of `EduTextGrade`s
+        """
+         
+         return Grades(self).get_text_grades(year=year, term=term)
 
     def get_user_id(self) -> str:
         """Get your EduPage user ID.


### PR DESCRIPTION
Fixes #71 
I've added a new class:
```python3
@dataclass
class EduTextGrade:
    grade_id: int
    comment: Optional[str]
    grade_type: int
    date: datetime
    subject_id: int
    subject_name: Optional[str]
```
And 2 new methods:
```python3
from edupage_api import Edupage, Term

edupage = Edupage()
edupage.login("Username", "Password", "Your school's subdomain")

# the new methods are equivalent to `edupage.get_grades` and `edupage.get_grades_for_term`
text_grades: list[EduTextGrade] = edupage.get_text_grades()
text_grades_t1: list[EduTextGrade] = edupage.get_text_grades_for_term(2024, Term.FIRST)
```

@mgrfilipmarek Can you please test? Feel free to suggest any more fields that should be added.

You can install the test version with this command:
```shell
pip install -U git+https://github.com/EdupageAPI/edupage-api@feature/text-grades
```
And to revert back:
```shell
pip uninstall edupage-api
pip install edupage-api
```