### PR TITLE
Add a new method for fetching older notifications

### DIFF
--- a/edupage_api/__init__.py
+++ b/edupage_api/__init__.py
@@ -184,6 +184,20 @@ class Edupage(EdupageModule):
 
         return TimelineEvents(self).get_notifications()
 
+    def get_notification_history(self, date_from: date) -> list[TimelineEvent]:
+        """Get a list of all available notifications since `date_from` (until now).
+
+        This method can be used instead of `get_notifications` if notifications older than
+        1 month are needed.
+
+        Args:
+            date_from (datetime.date): The first day of the date range
+
+        Returns:
+            list[TimelineEvent]: List of all notifications since `date_from` up to now.
+        """
+        return TimelineEvents(self).get_notifications_history(date_from)
+
     def cloud_upload(self, fd: TextIOWrapper) -> EduCloudFile:
         """Upload file to EduPage cloud.
 


### PR DESCRIPTION
This was my naive attempt at fixing #97.
After I read the rest of the pull request, I realized it can be solved by using this endpoint: `GET /dashboard/eb.php?mode=attendance`.

Example code:
```python3
from edupage_api import Edupage
from edupage_api.timeline import EventType, TimelineEvents

from datetime import datetime, timedelta

edupage = Edupage()
edupage.login("Username", "Password", "Your school's subdomain")

# new method!
# get all notifications since two months ago until now
notifications = TimelineEvents(edupage).get_notifications_history(
    datetime.now() - timedelta(days=30 * 2)
)

homework_count = 0
for notification in notifications:
    if notification.event_type == EventType.HOMEWORK:
        homework_count += 1

print(f"Homework count in the last 60 days: {homework_count}")
```