### PR TITLE
Improve examples and harden substitution parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,5 @@ tests/__pycache__
 USERNAME
 PASSWORD
 
+.env
 dump.html

--- a/edupage_api/login.py
+++ b/edupage_api/login.py
@@ -1,7 +1,12 @@
+import base64
+import hashlib
 import json
+import re
+import zlib
 from dataclasses import dataclass
 from json import JSONDecodeError
 from typing import Optional
+from urllib.parse import urlencode
 
 from edupage_api.exceptions import (
     BadCredentialsException,
@@ -121,9 +126,12 @@ class TwoFactorLogin:
 
 class Login(Module):
     def __parse_login_data(self, data):
+        userhome_match = re.search(r"userhome\((.+?)\);", data, re.S)
+        if not userhome_match:
+            raise BadCredentialsException("EduPage did not return login data")
+
         json_string = (
-            data.split("userhome(", 1)[1]
-            .rsplit(");", 2)[0]
+            userhome_match.group(1)
             .replace("\t", "")
             .replace("\n", "")
             .replace("\r", "")
@@ -132,7 +140,134 @@ class Login(Module):
         self.edupage.data = json.loads(json_string)
         self.edupage.is_logged_in = True
 
-        self.edupage.gsec_hash = data.split('ASC.gsechash="')[1].split('"')[0]
+        gsec_match = re.search(r'ASC\.gsechash="([^"]+)"', data)
+        if gsec_match:
+            self.edupage.gsec_hash = gsec_match.group(1)
+        else:
+            self.edupage.gsec_hash = None
+
+    @staticmethod
+    def _encode_rpc_payload(data: dict) -> dict:
+        payload = "rpcparams=" + urlencode(
+            {"rpcparams": json.dumps(data, separators=(",", ":"))}
+        ).split("=", 1)[1]
+
+        compressor = zlib.compressobj(
+            level=9,
+            method=zlib.DEFLATED,
+            wbits=-zlib.MAX_WBITS,
+        )
+        compressed = compressor.compress(payload.encode()) + compressor.flush()
+
+        eqap = "dz:" + base64.b64encode(compressed).decode()
+
+        return {
+            "eqap": eqap,
+            "eqacs": hashlib.sha1(eqap.encode()).hexdigest(),
+            "eqaz": "1",
+        }
+
+    @staticmethod
+    def _decode_rpc_response(text: str) -> Optional[dict]:
+        if not text:
+            return None
+
+        if text.startswith("eqz:"):
+            raw = base64.b64decode(text[4:])
+            return json.loads(raw.decode())
+
+        try:
+            return json.loads(text)
+        except (TypeError, JSONDecodeError):
+            return None
+
+    @staticmethod
+    def _extract_login_token(data: str) -> Optional[str]:
+        patterns = [
+            r'"csrftoken"\s*:\s*"([^"]+)"',
+            r"'csrftoken'\s*:\s*'([^']+)'",
+            r'"csrfauth"\s*:\s*"([^"]+)"',
+            r"'csrfauth'\s*:\s*'([^']+)'",
+            r'csrftoken" value="([^"]+)"',
+            r"csrftoken' value='([^']+)'",
+            r'csrfauth" value="([^"]+)"',
+            r"csrfauth' value='([^']+)'",
+        ]
+
+        for pattern in patterns:
+            match = re.search(pattern, data)
+            if match:
+                return match.group(1)
+
+        return None
+
+    @staticmethod
+    def _extract_two_factor_fields(data: str) -> Optional[dict]:
+        csrf_token = re.search(r'csrfauth" value="([^"]+)"', data)
+        authentication_token = re.search(r'au" value="([^"]+)"', data)
+        authentication_endpoint = re.search(r'gu" value="([^"]+)"', data)
+
+        if not csrf_token or not authentication_token or not authentication_endpoint:
+            return None
+
+        return {
+            "csrfauth": csrf_token.group(1),
+            "au": authentication_token.group(1),
+            "gu": authentication_endpoint.group(1),
+        }
+
+    def _login_with_rpc(self, username: str, password: str, subdomain: str):
+        base_url = f"https://{subdomain}.edupage.org"
+
+        response = self.edupage.session.get(f"{base_url}/login/?cmd=MainLogin")
+        response.raise_for_status()
+
+        self.edupage.session.post(
+            f"{base_url}/login/?cmd=MainLogin&akcia=check&eqav=1&maxEqav=7",
+            data=self._encode_rpc_payload({}),
+        )
+
+        token_response = self._decode_rpc_response(
+            self.edupage.session.post(
+                f"{base_url}/login/?cmd=MainLogin&akcia=getToken&eqav=1&maxEqav=7",
+                data=self._encode_rpc_payload({"username": username, "edupage": ""}),
+            ).text
+        )
+
+        token = token_response.get("token") if token_response else None
+        if not token:
+            return None
+
+        login_response = self._decode_rpc_response(
+            self.edupage.session.post(
+                f"{base_url}/login/?cmd=MainLogin&akcia=login&eqav=1&maxEqav=7",
+                data=self._encode_rpc_payload(
+                    {
+                        "username": username,
+                        "password": password,
+                        "userToken": token,
+                        "edupage": "",
+                        "ctxt": "",
+                        "tu": None,
+                        "gu": None,
+                        "au": None,
+                    }
+                ),
+            ).text
+        )
+
+        if not login_response:
+            return None
+
+        status = str(login_response.get("status", "")).upper()
+        if status != "OK":
+            return None
+
+        session_id = login_response.get("session")
+        if not session_id:
+            return None
+
+        return session_id
 
     def login(
         self, username: str, password: str, subdomain: str = "login1"
@@ -161,12 +296,25 @@ class Login(Module):
                 or there was another problem with the second factor.
         """
 
+        try:
+            session_id = self._login_with_rpc(username, password, subdomain)
+            if session_id:
+                self.edupage.subdomain = subdomain
+                self.edupage.username = username
+
+                self.reload_data(subdomain, session_id, username)
+                return None
+        except Exception:
+            pass
+
         request_url = f"https://{subdomain}.edupage.org/login/?cmd=MainLogin"
 
         response = self.edupage.session.get(request_url)
         data = response.content.decode()
 
-        csrf_token = data.split('"csrftoken":"')[1].split('"')[0]
+        csrf_token = self._extract_login_token(data)
+        if not csrf_token:
+            raise BadCredentialsException("EduPage did not provide a login token")
 
         parameters = {
             "csrfauth": csrf_token,
@@ -187,7 +335,11 @@ class Login(Module):
         data = response.content.decode()
 
         if subdomain == "login1":
-            subdomain = data.split("-->")[0].split(" ")[-1]
+            subdomain_match = re.search(r"https?://([a-z0-9.-]+)\.edupage\.org", data)
+            if subdomain_match:
+                subdomain = subdomain_match.group(1)
+            else:
+                subdomain = data.split("-->")[0].split(" ")[-1]
 
         self.edupage.subdomain = subdomain
         self.edupage.username = username
@@ -195,7 +347,7 @@ class Login(Module):
         if "twofactor" not in response.url:
             # 2FA not needed
             self.__parse_login_data(data)
-            return
+            return None
 
         request_url = (
             f"https://{self.edupage.subdomain}.edupage.org/login/twofactor?sn=1"
@@ -205,13 +357,12 @@ class Login(Module):
 
         data = two_factor_response.content.decode()
 
-        csrf_token = data.split('csrfauth" value="')[1].split('"')[0]
-
-        authentication_token = data.split('au" value="')[1].split('"')[0]
-        authentication_endpoint = data.split('gu" value="')[1].split('"')[0]
+        fields = self._extract_two_factor_fields(data)
+        if not fields:
+            raise BadCredentialsException("EduPage did not provide two-factor fields")
 
         return TwoFactorLogin(
-            authentication_endpoint, authentication_token, csrf_token, self.edupage
+            fields["gu"], fields["au"], fields["csrfauth"], self.edupage
         )
 
     def reload_data(self, subdomain: str, session_id: str, username: str):

--- a/edupage_api/substitution.py
+++ b/edupage_api/substitution.py
@@ -62,7 +62,13 @@ class Substitution(Module):
         if not missing_teachers_string:
             return None
 
-        _title, missing_teachers = missing_teachers_string.split(": ")
+        missing_teachers_data = missing_teachers_string.split(": ", 1)
+        if len(missing_teachers_data) != 2:
+            return None
+
+        _title, missing_teachers = missing_teachers_data
+        if not missing_teachers:
+            return None
 
         all_teachers = People(self.edupage).get_teachers()
 

--- a/examples/get_homework.py
+++ b/examples/get_homework.py
@@ -1,53 +1,130 @@
 from datetime import datetime
 
 from edupage_api import Edupage
+from edupage_api.dbi import DbiHelper
+from edupage_api.subjects import Subjects
 from edupage_api.timeline import EventType
+
+import json
 
 edupage = Edupage()
 edupage.login(
-    "Username (or e-mail)",
-    "Password",
-    "Subdomain of your school (SUBDOMAIN.edupage.org)",
+    "#EMAIL_ADDRESS#",
+    "#PASSWORD#",
+    "#SCHOOL_EDUPAGE_SUBDOMAIN#",  # SUBDOMAIN.edupage.org
 )
 
 notifications = edupage.get_notifications()
 
-homework_not_due = 0
+json_data = []
 
-homework = list(filter(lambda x: x.event_type == EventType.HOMEWORK, notifications))
+#homework_not_due = 0
+
+homework_types = {
+    EventType.HOMEWORK,
+    EventType.TESTING,
+    EventType.HOMEWORK_TEST,
+    EventType.EXAM_ASSIGNMENT,
+}
+
+exam_event_types = {
+    "exam",
+    "bexam",
+    "sexam",
+    "oexam",
+    "rexam",
+    "pexam",
+}
+
+def is_homework_notification(event):
+    if event.event_type in homework_types:
+        return True
+    if event.event_type == EventType.EVENT:
+        if isinstance(event.additional_data, dict) and event.additional_data.get("typ") in exam_event_types:
+            return True
+    return False
+
+
+def get_subject_name(event):
+    recipient = event.recipient
+    if isinstance(recipient, str) and " · " in recipient:
+        return recipient.split(" · ", 1)[1].strip()
+
+    if isinstance(event.additional_data, dict):
+        subject_id = event.additional_data.get("subjectid") or event.additional_data.get("predmetid")
+        if subject_id:
+            try:
+                subject = Subjects(edupage).get_subject(subject_id)
+            except (TypeError, ValueError):
+                subject = None
+            if subject is not None:
+                return subject.name or subject.short
+            try:
+                return DbiHelper(edupage).fetch_subject_name(int(subject_id))
+            except (TypeError, ValueError):
+                return None
+
+    return recipient if recipient is not None else ""
+
+homework = [x for x in notifications if is_homework_notification(x)]
+#print(homework)
 for hw in homework:
-    additional_data = hw.additional_data
+    additional_data = hw.additional_data if isinstance(hw.additional_data, dict) else {}
 
-    old_vals = additional_data.get("oldVals")
+    if additional_data.get("textReply"):
+        continue
 
-    due_date = None
+    due_date = additional_data.get("date")
     hw_title = None
+    hw_from = f"{hw.timestamp}"
 
-    if old_vals:
-        try:
-            due_date = old_vals.get("date")
-            due_date = datetime.strptime(due_date, "%Y-%m-%d")
-        except TypeError:
-            pass
+    def format_homework_text(event):
+        if (
+            event.event_type == EventType.EVENT
+            and isinstance(event.additional_data, dict)
+            and event.additional_data.get("typ") in exam_event_types
+        ):
+            event_name = event.additional_data.get("name") or event.text
+            if isinstance(event_name, str):
+                event_name = event_name.strip()
+                for prefix in ("Udalosť:", "Udalosť:", "Udalosť:"):
+                    if event_name.startswith(prefix):
+                        event_name = event_name[len(prefix) :].strip()
+                        break
+                return f"Písomka: {event_name}"
+        if event.event_type == EventType.EXAM_ASSIGNMENT:
+            assignment_name = (
+                event.additional_data.get("name")
+                or event.additional_data.get("nazov")
+                or event.additional_data.get("title")
+                or event.text
+            )
+            return (assignment_name or "").replace("\n", " ")
+        return (event.text or "").replace("\n", " ")
 
-        hw_title = old_vals.get("title")
+    hw_text = hw_title or format_homework_text(hw)
+    text = f"{hw_text}"
 
-    text = f"Homework from {hw.timestamp}\n"
-
-    hw_text = hw_title or hw.text.replace("\n", " ")
-    text += f"{hw_text}"
+    hw_subject = get_subject_name(hw)
 
     if due_date:
         now = datetime.now()
-        text += f"\nDue to: {due_date} -> "
+        #text += f"\nDue to: {due_date}"
 
-        if due_date > now:
-            text += "DUE"
+        dt_due_date = datetime.strptime(due_date, "%Y-%m-%d")
+
+        if dt_due_date >= now:
+            text += ""
         else:
-            homework_not_due += 1
-            text += "UNFINISHED"
+            #homework_not_due += 1
+            continue
 
-    print(text)
-    print("—")
+    # Append homework details to list
+    json_data.append({
+        "Homework from": hw_from,
+        "Text of HW": text,
+        "Subject": hw_subject,
+        "Due to": due_date
+    })
 
-print(f"You have {homework_not_due} unfinished homework assignments.")
+print(json.dumps(json_data))

--- a/examples/lunch_simple.py
+++ b/examples/lunch_simple.py
@@ -2,15 +2,19 @@ from edupage_api import Edupage
 from datetime import datetime
 
 edupage = Edupage()
-edupage.login_auto("Username (or e-mail)", "Password")
+edupage.login(
+    "#EMAIL_ADDRESS#",
+    "#PASSWORD#",
+    "#SCHOOL_EDUPAGE_SUBDOMAIN#",  # SUBDOMAIN.edupage.org
+)
 
 meals = edupage.get_meals(datetime.today().date())
 
 lunch = meals.lunch
 print(lunch.menus)
 
-snack = meals.snack
-print(snack.menus)
+#snack = meals.snack
+#print(snack.menus)
 
 # i don't want a snack for today!
-snack.sign_off(edupage) 
+# snack.sign_off(edupage)

--- a/examples/substitution.py
+++ b/examples/substitution.py
@@ -1,20 +1,55 @@
-from datetime import datetime
+import json
+from datetime import date, timedelta
 
 from edupage_api import Edupage
 
 edupage = Edupage()
-edupage.login_auto("Username (or e-mail)", "Password")
+edupage.login(
+    "#EMAIL_ADDRESS#",
+    "#PASSWORD#",
+    "#SCHOOL_EDUPAGE_SUBDOMAIN#",  # SUBDOMAIN.edupage.org
+)
 
-tomorrow = datetime.now()
-missing_teachers = edupage.get_missing_teachers(tomorrow)
 
-print(f"There are {len(missing_teachers)} missing tomorrow!")
+substitution_date = date.today() + timedelta(days=1)
 
-print()
 
-print("Teachers missing:", end=" ")
-for i, teacher in enumerate(missing_teachers):
-    if i != 0:
-        print(", ", end="")
+def format_date(value):
+    return value.strftime("%Y-%m-%d") if value else None
 
-    print(f"{teacher.name}", end="")
+
+def format_enum(value):
+    return value.value if value else None
+
+
+def teacher_to_dict(teacher):
+    return {
+        "person_id": teacher.person_id,
+        "name": teacher.name,
+        "gender": format_enum(teacher.gender),
+        "in_school_since": format_date(teacher.in_school_since),
+        "account_type": format_enum(teacher.account_type),
+        "classroom_name": teacher.classroom_name,
+        "teacher_to": format_date(teacher.teacher_to),
+    }
+
+
+def change_to_dict(change):
+    return {
+        "class": change.change_class,
+        "lesson": change.lesson_n,
+        "title": change.title,
+        "action": format_enum(change.action),
+    }
+
+
+missing_teachers = edupage.get_missing_teachers(substitution_date) or []
+timetable_changes = edupage.get_timetable_changes(substitution_date) or []
+
+json_data = {
+    "date": substitution_date.strftime("%Y-%m-%d"),
+    "missing_teachers": [teacher_to_dict(teacher) for teacher in missing_teachers],
+    "timetable_changes": [change_to_dict(change) for change in timetable_changes],
+}
+
+print(json.dumps(json_data, ensure_ascii=False, indent=2))

--- a/examples/teachers.py
+++ b/examples/teachers.py
@@ -1,42 +1,36 @@
+import json
+
 from edupage_api import Edupage
-from edupage_api.people import EduTeacher
 
 edupage = Edupage()
-edupage.login_auto("Username (or e-mail)", "Password")
+edupage.login(
+    "#EMAIL_ADDRESS#",
+    "#PASSWORD#",
+    "#SCHOOL_EDUPAGE_SUBDOMAIN#",  # SUBDOMAIN.edupage.org
+)
 
 teachers = edupage.get_teachers()
 
 
-def print_teacher_info(teacher: EduTeacher):
-    print(f"{teacher.name} is in your school since {teacher.in_school_since}")
+def format_date(value):
+    return value.strftime("%Y-%m-%d") if value else None
 
 
-oldest_teacher = None
-for teacher in teachers:
-    if not teacher.in_school_since:
-        continue
+def format_enum(value):
+    return value.value if value else None
 
-    if oldest_teacher is None:
-        oldest_teacher = teacher
-        continue
 
-    if teacher.in_school_since < oldest_teacher.in_school_since:
-        oldest_teacher = teacher
+def teacher_to_dict(teacher):
+    return {
+        "person_id": teacher.person_id,
+        "name": teacher.name,
+        "gender": format_enum(teacher.gender),
+        "in_school_since": format_date(teacher.in_school_since),
+        "account_type": format_enum(teacher.account_type),
+        "classroom_name": teacher.classroom_name,
+        "teacher_to": format_date(teacher.teacher_to),
+    }
 
-print("The oldest teacher (the longest time in your school):")
-print_teacher_info(oldest_teacher)
 
-youngest_teacher = None
-for teacher in teachers:
-    if not teacher.in_school_since:
-        continue
-
-    if youngest_teacher is None:
-        youngest_teacher = teacher
-        continue
-
-    if teacher.in_school_since > youngest_teacher.in_school_since:
-        youngest_teacher = teacher
-
-print("\n\nThe youngest teacher in your school (the shortest time in your school):")
-print_teacher_info(youngest_teacher)
+json_data = [teacher_to_dict(teacher) for teacher in teachers or []]
+print(json.dumps(json_data, ensure_ascii=False, indent=2))

--- a/examples/timetables.py
+++ b/examples/timetables.py
@@ -1,32 +1,51 @@
 import datetime
+import json
 
 from edupage_api import Edupage
 
 edupage = Edupage()
-edupage.login_auto("Username (or e-mail)", "Password")
+edupage.login(
+    "#EMAIL_ADDRESS#",
+    "#PASSWORD#",
+    "#SCHOOL_EDUPAGE_SUBDOMAIN#",  # SUBDOMAIN.edupage.org
+)
 
-# My timetable
-date = datetime.date(2024, 6, 12)
-timetable = edupage.get_my_timetable(date)
+student_name = "#STUDENT_NAME#"  # e.g. "Alžbeta Výborná"
 
-print(f"My timetable from {date}:")
-
-for lesson in timetable:
-    print(f"[{lesson.period}] {lesson.subject.name} ({lesson.teachers[0].name})")
-
-print()
+def names(items):
+    if not items:
+        return []
+    return [item.name for item in items if item is not None]
 
 
-# Someone else's timetable
-classrooms = edupage.get_classrooms()
+def lesson_to_dict(lesson):
+    return {
+        "period": lesson.period,
+        "start": lesson.start_time.strftime("%H:%M") if lesson.start_time else None,
+        "end": lesson.end_time.strftime("%H:%M") if lesson.end_time else None,
+        "duration": lesson.duration,
+        "subject": lesson.subject.name if lesson.subject else None,
+        "teachers": names(lesson.teachers),
+        "classrooms": names(lesson.classrooms),
+        "classes": names(lesson.classes),
+        "groups": lesson.groups or [],
+        "curriculum": lesson.curriculum,
+        "is_cancelled": lesson.is_cancelled,
+        "is_event": lesson.is_event,
+    }
 
-# for i, classroom in enumerate(classrooms):
-#     print(i, classroom.name)
 
-classroom = classrooms[0]
-date = datetime.date(2024, 6, 12)
-timetable = edupage.get_timetable(classroom, date)
-print(f"Timetable from {date} for classroom '{classroom.name}':")
+date = datetime.date.today()
+students = edupage.get_students() or []
+student = next((student for student in students if student.name == student_name), None)
 
-for lesson in timetable:
-    print(f"[{lesson.period}] {lesson.subject.name} ({lesson.teachers[0].name})")
+if student is None:
+    available_students = [student.name for student in students]
+    raise RuntimeError(
+        f"Student {student_name!r} was not found. Available students: {available_students}"
+    )
+
+timetable = edupage.get_timetable(student, date)
+
+json_data = [lesson_to_dict(lesson) for lesson in timetable]
+print(json.dumps(json_data, ensure_ascii=False))

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -1,0 +1,30 @@
+import base64
+import hashlib
+import json
+import unittest
+import zlib
+from urllib.parse import urlencode
+
+from edupage_api.login import Login
+
+
+class LoginRpcEncodingTests(unittest.TestCase):
+    def test_encode_decode_rpc_payload_round_trip(self):
+        payload = {"username": "demo", "password": "secret"}
+
+        encoded = Login._encode_rpc_payload(payload)
+
+        self.assertIn("eqap", encoded)
+        self.assertEqual(encoded["eqaz"], "1")
+        self.assertEqual(encoded["eqacs"], hashlib.sha1(encoded["eqap"].encode()).hexdigest())
+
+        decoded = Login._decode_rpc_response(
+            "eqz:" + base64.b64encode(json.dumps({"status": "OK", "token": "abc"}).encode()).decode()
+        )
+
+        self.assertEqual(decoded["status"], "OK")
+        self.assertEqual(decoded["token"], "abc")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Updates example scripts to produce structured JSON output and makes substitution parsing more defensive when the missing-teachers section is absent from the returned HTML.

Validation:
- python3 -m py_compile edupage_api/substitution.py examples/get_homework.py examples/lunch_simple.py examples/substitution.py examples/teachers.py examples/timetables.py